### PR TITLE
 refactor (src/user/blocks.js) - fixed blocks.can arguments

### DIFF
--- a/src/socket.io/user/profile.js
+++ b/src/socket.io/user/profile.js
@@ -45,7 +45,7 @@ module.exports = function (SocketUser) {
 		if (action !== 'block' && action !== 'unblock') {
 			throw new Error('[[error:unknow-block-action]]');
 		}
-		await user.blocks.can(socket.uid, blockerUid, blockeeUid, action);
+		await user.blocks.can({callerUid: socket.uid, blockerUid, blockeeUid}, action);
 		if (data.action === 'block') {
 			await user.blocks.add(blockeeUid, blockerUid);
 		} else if (data.action === 'unblock') {

--- a/src/user/blocks.js
+++ b/src/user/blocks.js
@@ -24,7 +24,7 @@ module.exports = function (User) {
 		return isArray ? isBlocked : isBlocked[0];
 	};
 
-	User.blocks.can = async function (callerUid, blockerUid, blockeeUid, type) {
+	User.blocks.can = async function ({callerUid, blockerUid, blockeeUid}, type) {
 		// Guests can't block
 		if (blockerUid === 0 || blockeeUid === 0) {
 			throw new Error('[[error:cannot-block-guest]]');
@@ -79,7 +79,11 @@ module.exports = function (User) {
 	};
 
 	User.blocks.applyChecks = async function (type, targetUid, uid) {
-		await User.blocks.can(uid, uid, targetUid);
+		await User.blocks.can({
+			callerUid: uid,
+			blockerUid: uid,
+			blockeeUid: targetUid,
+		});
 		const isBlock = type === 'block';
 		const is = await User.blocks.is(targetUid, uid);
 		if (is === isBlock) {


### PR DESCRIPTION
Refactor (src/user/blocks.js): fixed blocks.can method having too many arguments.

User.blocks.can function. I changed its parameters to accept an object for the user IDs to reduce the number of arguments. Also, in blocks.applyChecks and profile.toggleBlock (in src/user/profile.js)i updated the calls so it passes in a object to the user IDs instead of multiple parameters like it was done before.