### PR TITLE
feat(posts): add banned words validation for post content

### DIFF
--- a/src/meta/bannedwords.js
+++ b/src/meta/bannedwords.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// TODO: Uncomment these imports when implementing database storage
+// const db = require('../database');
+// const pubsub = require('../pubsub');
+
+const BannedWords = module.exports;
+
+// Hardcoded list of banned words for first sprint
+BannedWords._words = [
+	'spam',
+	'badword',
+	'inappropriate',
+	'offensive',
+	'hate',
+	'abuse',
+	// Add more words as needed
+];
+
+// TODO: Implement database-driven banned words management
+// When ready to move from hardcoded to dynamic banned words:
+// 1. Uncomment the db and pubsub imports at the top
+// 2. Implement load() function to retrieve words from database and populate _words array
+// 3. Implement save() function to store words to database and notify other instances
+// 4. Implement get() function to retrieve raw words string from database
+// 5. Set up pubsub listener to reload when words are updated
+// 6. Replace hardcoded _words array with database-driven approach
+
+BannedWords.getList = function () {
+	return BannedWords._words;
+};

--- a/src/meta/index.js
+++ b/src/meta/index.js
@@ -22,6 +22,7 @@ Meta.tags = require('./tags');
 Meta.dependencies = require('./dependencies');
 Meta.templates = require('./templates');
 Meta.blacklist = require('./blacklist');
+Meta.bannedwords = require('./bannedwords');
 Meta.languages = require('./languages');
 
 const user = require('../user');

--- a/src/posts/parse.js
+++ b/src/posts/parse.js
@@ -142,6 +142,11 @@ module.exports = function (Posts) {
 		plugins.hooks.register('core', {
 			hook: 'filter:parse.post',
 			method: async (data) => {
+				// how do i pull in a json file to get a json file containing a list of bannedWords and run my fun
+
+				//
+				//
+
 				data.postData.content = Posts[data.type !== 'plaintext' ? 'sanitize' : 'sanitizePlaintext'](data.postData.content);
 				return data;
 			},

--- a/src/posts/validate.js
+++ b/src/posts/validate.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const meta = require('../meta');
+
+// postData: object with at least 'title' and 'content'
+// returns: object { allowed: boolean, banned: string[] }
+function checkPostDataForBannedContent(postData) {
+	const bannedWords = meta.bannedwords.getList();
+	const bannedFound = [];
+	const text = `${postData.title || ''} ${postData.content || ''}`.toLowerCase();
+
+	for (const word of bannedWords) {
+		const regex = new RegExp(`\\b${word.toLowerCase()}\\b`, 'i');
+		if (regex.test(text)) {
+			bannedFound.push(word);
+		}
+	}
+
+	return {
+		allowed: (bannedFound.length === 0),
+		banned: bannedFound,
+	};
+}
+
+module.exports = {
+	checkPostDataForBannedContent,
+};

--- a/src/socket.io/admin.js
+++ b/src/socket.io/admin.js
@@ -29,6 +29,7 @@ SocketAdmin.email = require('./admin/email');
 SocketAdmin.analytics = require('./admin/analytics');
 SocketAdmin.logs = require('./admin/logs');
 SocketAdmin.errors = require('./admin/errors');
+SocketAdmin.bannedwords = require('./admin/bannedwords');
 SocketAdmin.digest = require('./admin/digest');
 SocketAdmin.cache = require('./admin/cache');
 

--- a/src/socket.io/admin/bannedwords.js
+++ b/src/socket.io/admin/bannedwords.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const user = require('../../user');
+// TODO: Uncomment when implementing database functionality
+// const meta = require('../../meta');
+// const events = require('../../events');
+
+const SocketBannedWords = module.exports;
+
+SocketBannedWords.save = async function (socket, words) {
+	const isAdminOrGlobalMod = await user.isAdminOrGlobalMod(socket.uid);
+	if (!isAdminOrGlobalMod) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	// TODO: Implement banned words saving to database
+	// When implementing: uncomment meta and events imports, call meta.bannedwords.save(words),
+	// and log the event with events.log() for admin audit trail
+	throw new Error(`Banned words management not yet implemented - using hardcoded list. Received: ${words}`);
+};
+
+SocketBannedWords.get = async function (socket) {
+	const isAdminOrGlobalMod = await user.isAdminOrGlobalMod(socket.uid);
+	if (!isAdminOrGlobalMod) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	// TODO: Implement banned words retrieval from database
+	// When implementing: return meta.bannedwords.get() to allow admin interface
+	// to display current banned words for editing in the admin panel
+	throw new Error('Banned words management not yet implemented - using hardcoded list');
+};
+
+require('../../promisify')(SocketBannedWords);


### PR DESCRIPTION
## Summary
Implements banned words validation function for post titles and content to prevent inappropriate content from being posted.

## Changes
- Add `validate.js` module with `checkPostDataForBannedContent()` function
- Add `bannedwords.js` module with hardcoded banned words list for first sprint
- Implement word boundary regex matching to prevent false positives
- Set up infrastructure for future database-driven banned words management