### PR TITLE
Use i18n error for banned keywords in posts/topics

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -99,6 +99,7 @@
 
 	"content-too-short": "Please enter a longer post. Posts should contain at least %1 character(s).",
 	"content-too-long": "Please enter a shorter post. Posts can't be longer than %1 character(s).",
+	"post-has-banned-keywords": "Your post contains sensitive or banned keywords: %1",
 	"title-too-short": "Please enter a longer title. Titles should contain at least %1 character(s).",
 	"title-too-long": "Please enter a shorter title. Titles can't be longer than %1 character(s).",
 	"category-not-selected": "Category not selected.",

--- a/public/language/en-US/error.json
+++ b/public/language/en-US/error.json
@@ -87,6 +87,7 @@
     "cant-delete-topic-has-replies": "You can't delete your topic after it has %1 replies",
     "content-too-short": "Please enter a longer post. Posts should contain at least %1 character(s).",
     "content-too-long": "Please enter a shorter post. Posts can't be longer than %1 character(s).",
+    "post-has-banned-keywords": "Your post contains sensitive or banned keywords: %1",
     "title-too-short": "Please enter a longer title. Titles should contain at least %1 character(s).",
     "title-too-long": "Please enter a shorter title. Titles can't be longer than %1 character(s).",
     "category-not-selected": "Category not selected.",

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -124,7 +124,8 @@ postsAPI.edit = async function (caller, data) {
 		});
 		if (scan && scan.allowed === false) {
 			const bannedList = Array.isArray(scan.banned) ? scan.banned.join(', ') : '';
-			throw new Error(`Your post contains sensitive or banned keywords: ${bannedList}`);
+			const escaped = bannedList.replace(/%/g, '&#37;').replace(/,/g, '&#44;');
+			throw new Error(`[[error:post-has-banned-keywords, ${escaped}]]`);
 		}
 	}
 

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -84,7 +84,8 @@ topicsAPI.create = async function (caller, data) {
 		});
 		if (scan && scan.allowed === false) {
 			const bannedList = Array.isArray(scan.banned) ? scan.banned.join(', ') : '';
-			throw new Error(`Your post contains sensitive or banned keywords: ${bannedList}`);
+			const escaped = bannedList.replace(/%/g, '&#37;').replace(/,/g, '&#44;');
+			throw new Error(`[[error:post-has-banned-keywords, ${escaped}]]`);
 		}
 	}
 	const shouldQueue = await posts.shouldQueue(caller.uid, payload);
@@ -124,7 +125,8 @@ topicsAPI.reply = async function (caller, data) {
 		});
 		if (scan && scan.allowed === false) {
 			const bannedList = Array.isArray(scan.banned) ? scan.banned.join(', ') : '';
-			throw new Error(`Your post contains sensitive or banned keywords: ${bannedList}`);
+			const escaped = bannedList.replace(/%/g, '&#37;').replace(/,/g, '&#44;');
+			throw new Error(`[[error:post-has-banned-keywords, ${escaped}]]`);
 		}
 	}
 	const shouldQueue = await posts.shouldQueue(caller.uid, payload);


### PR DESCRIPTION
Replaces hardcoded error messages for banned keywords in posts and topics with an i18n key and escapes special characters. Adds the 'post-has-banned-keywords' entry to English error message files for better localization support.