### PR TITLE
Fix failing banned keyword validation tests in posts.js

### DIFF
--- a/test/posts.js
+++ b/test/posts.js
@@ -783,8 +783,11 @@ describe('Post\'s', () => {
 		let validate;
 		
 		before(async () => {
-			// Import the validate module
 			validate = require('../src/posts/validate');
+			
+			// Initialize banned words for tests
+			const bannedWords = require('../src/meta/bannedwords');
+			await bannedWords.init();
 		});
 
 		describe('checkPostDataForBannedContent', () => {
@@ -874,7 +877,7 @@ describe('Post\'s', () => {
 					});
 					assert(false, 'Expected post creation to fail');
 				} catch (err) {
-					assert(err.message.includes('Your post contains sensitive or banned keywords'));
+					assert(err.message.includes('post-has-banned-keywords'));
 					assert(err.message.includes('spam'));
 				}
 			});
@@ -888,7 +891,7 @@ describe('Post\'s', () => {
 					});
 					assert(false, 'Expected post creation to fail');
 				} catch (err) {
-					assert(err.message.includes('Your post contains sensitive or banned keywords'));
+					assert(err.message.includes('post-has-banned-keywords'));
 					assert(err.message.includes('hate'));
 				}
 			});
@@ -901,7 +904,7 @@ describe('Post\'s', () => {
 					});
 					assert(false, 'Expected reply creation to fail');
 				} catch (err) {
-					assert(err.message.includes('Your post contains sensitive or banned keywords'));
+					assert(err.message.includes('post-has-banned-keywords'));
 					assert(err.message.includes('abuse'));
 				}
 			});
@@ -920,7 +923,7 @@ describe('Post\'s', () => {
 					});
 					assert(false, 'Expected post creation to fail');
 				} catch (err) {
-					assert(err.message.includes('Your post contains sensitive or banned keywords'));
+					assert(err.message.includes('post-has-banned-keywords'));
 					assert(err.message.includes('spam'));
 					
 					// Verify no topic or post was actually created


### PR DESCRIPTION
# Summary
This PR fixes failing tests in `posts.js` related to banned keyword validation in posts and replies.  
The issue was caused by the banned words list not being initialized before running the tests, leading to false negatives for banned content detection.

# Changes Made
### Test Setup Improvement
- Added initialization of the banned words list (`bannedWords.init()`) in the `before` block to ensure banned keywords are loaded into the database before any tests run.

### Error Message Assertion Update
- Updated test assertions to match the actual error format.  
  In the test environment, NodeBB returns raw translation keys (e.g., `post-has-banned-keywords`) instead of translated strings.  
  Assertions now verify that the error message includes both the translation key **and** the banned word.

### Validation Coverage
- Confirmed that:
  - Topic creation fails when content contains banned words.
  - Reply creation fails when content contains banned words.
  - No database writes occur when banned content is detected (topic/post counts do not increment).
  - Error messages include both the translation key and the banned word.

# Rationale
Previously, tests with banned words passed without triggering validation errors because the banned words list was not loaded.  
This PR ensures the test environment reflects production behavior for banned content validation.

# Impact
- All relevant tests now pass, confirming banned content is blocked at the API layer.
- Improves reliability and coverage of banned keyword validation logic.

# How to Test
1. Run:
   ```bash
   npm test test/posts.js