### PR TITLE
feat (LLM Translation): [INTO MAIN] Added LLM Translator UI and API Integration with Microservice

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -18,6 +18,10 @@ PostObject:
         For posts received via ActivityPub, it is the url of the original piece of content.
     content:
       type: string
+    isEnglish:
+      type: boolean
+    translatedContent:
+      type: string
     sourceContent:
       type: string
       nullable: true
@@ -193,6 +197,10 @@ PostDataObject:
           description: A topic identifier
         content:
           type: string
+        isEnglish:
+          type: boolean
+        translatedContent:
+          type: string      
         timestamp:
           type: number
         votes:

--- a/public/openapi/read/categories.yaml
+++ b/public/openapi/read/categories.yaml
@@ -82,6 +82,10 @@ get:
                                               type: number
                                             content:
                                               type: string
+                                            isEnglish:
+                                              type: boolean
+                                            translatedContent:
+                                              type: string                                            
                                             timestampISO:
                                               type: string
                                               description: An ISO 8601 formatted date string (complementing `timestamp`)
@@ -142,6 +146,10 @@ get:
                                     type: number
                                   content:
                                     type: string
+                                  isEnglish:
+                                    type: boolean
+                                  translatedContent:
+                                    type: string 
                                   sourceContent:
                                     type: string
                                     nullable: true

--- a/public/openapi/read/index.yaml
+++ b/public/openapi/read/index.yaml
@@ -77,6 +77,10 @@ get:
                                               type: number
                                             content:
                                               type: string
+                                            isEnglish:
+                                              type: boolean
+                                            translatedContent:
+                                              type: string                                            
                                             timestampISO:
                                               type: string
                                               description: An ISO 8601 formatted date string (complementing `timestamp`)
@@ -144,6 +148,10 @@ get:
                                     type: number
                                   content:
                                     type: string
+                                  isEnglish:
+                                    type: boolean
+                                  translatedContent:
+                                    type: string  
                                   sourceContent:
                                     type: string
                                     nullable: true

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -35,6 +35,10 @@ get:
                         description: A topic identifier
                       content:
                         type: string
+                      isEnglish:
+                        type: boolean
+                      translatedContent:
+                        type: string                      
                       timestamp:
                         type: number
                       flagId:

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -74,10 +74,27 @@ define('forum/topic', [
 
 		$(window).on('scroll', utils.debounce(updateTopicTitle, 250));
 
+		configurePostToggle();
+
 		handleTopicSearch();
 
 		hooks.fire('action:topic.loaded', ajaxify.data);
 	};
+
+	function configurePostToggle() {
+		$('.topic').on('click', '.view-translated-btn', function () {
+			// Toggle the visibility of the next .translated-content div
+			$(this).closest('.sensitive-content-message').next('.translated-content').toggle();
+			// Optionally, change the button text based on visibility
+			var isVisible = $(this).closest('.sensitive-content-message').next('.translated-content').is(':visible');
+			if (isVisible) {
+				$(this).text('Hide the translated message.');
+			} else {
+				$(this).text('Click here to view the translated message.');
+			}
+		});
+	}
+
 
 	function handleTopicSearch() {
 		require(['mousetrap'], (mousetrap) => {

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -10,6 +10,7 @@ const groups = require('../groups');
 const privileges = require('../privileges');
 const activitypub = require('../activitypub');
 const utils = require('../utils');
+const translate = require('../translate');
 
 module.exports = function (Posts) {
 	Posts.create = async function (data) {
@@ -18,6 +19,7 @@ module.exports = function (Posts) {
 		const content = data.content.toString();
 		const timestamp = data.timestamp || Date.now();
 		const isMain = data.isMain || false;
+		const [isEnglish, translatedContent] = await translate.translate(data);
 
 		if (!uid && parseInt(uid, 10) !== 0) {
 			throw new Error('[[error:invalid-uid]]');
@@ -40,7 +42,7 @@ module.exports = function (Posts) {
 		}
 
 		const pid = data.pid || await db.incrObjectField('global', 'nextPid');
-		let postData = { pid, uid, tid, content, sourceContent, timestamp };
+		let postData = { pid, uid, tid, content, sourceContent, timestamp, isEnglish, translatedContent };
 
 		if (data.toPid) {
 			postData.toPid = data.toPid;

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -73,5 +73,11 @@ function modifyPost(post, fields) {
 		if (!fields.length || fields.includes('linkedThreadIds')) {
 			post.linkedThreadIds = (post.linkedThreadIds || '').split(',').filter(Boolean).map(id => parseInt(id, 10));
 		}
+		// Mark post as "English" if decided by translator service or if it has no info
+		post.isEnglish = post.isEnglish == 'true' || post.isEnglish === undefined;
+		// If translatedContent is undefined, default to empty string (no translation needed for English posts)
+		if (post.translatedContent === undefined) {
+			post.translatedContent = '';
+		}
 	}
 }

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -22,7 +22,10 @@ module.exports = function (Posts) {
 		options.escape = options.hasOwnProperty('escape') ? options.escape : false;
 		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'linkedThreadIds'].concat(options.extraFields);
+		// const fields = ['pid', 'tid', 'toPid', 'url', 'content', 
+		// 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes',
+		// 'downvotes', 'replies', 'handle', 'linkedThreadIds'].concat(options.extraFields);
+		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'linkedThreadIds', 'isEnglish', 'translatedContent'].concat(options.extraFields);
 
 		let posts = await Posts.getPostsFields(pids, fields);
 		posts = posts.filter(Boolean);

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,0 +1,17 @@
+
+/* eslint-disable strict */
+//var request = require('request');
+
+const translatorApi = module.exports;
+
+translatorApi.translate = function (postData) {
+	return ['is_english',postData];
+};
+
+// translatorApi.translate = async function (postData) {
+//  Edit the translator URL below
+//  const TRANSLATOR_API = "TODO"
+//  const response = await fetch(TRANSLATOR_API+'/?content='+postData.content);
+//  const data = await response.json();
+//  return ['is_english','translated_content'];
+// };

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,7 +1,4 @@
-
 /* eslint-disable strict */
-//var request = require('request');
-
 const translatorApi = module.exports;
 
 // translatorApi.translate = async function (postData) {

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -9,13 +9,13 @@ const translatorApi = module.exports;
 // };
 
 translatorApi.translate = async function (postData) {
-    const TRANSLATOR_API = 'http://host.docker.internal:5000';
-    try {
-        const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
-        const data = await response.json();
-        return [data.is_english, data.translated_content];
-    } catch (e) {
-        // If the API is down or any error occurs, return false and the original postData
-        return [false, postData];
-    }
+	const TRANSLATOR_API = 'http://host.docker.internal:5000';
+	try {
+		const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
+		const data = await response.json();
+		return [data.is_english, data.translated_content];
+	} catch (e) {
+		// If the API is down or any error occurs, return false and the original postData
+		return [false, postData];
+	}
 };

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -4,14 +4,9 @@
 
 const translatorApi = module.exports;
 
-translatorApi.translate = function (postData) {
-	return ['is_english',postData];
+translatorApi.translate = async function (postData) {
+    const TRANSLATOR_API = 'http://host.docker.internal:5000';
+    const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
+    const data = await response.json();
+    return [data.is_english, data.translated_content];
 };
-
-// translatorApi.translate = async function (postData) {
-//  Edit the translator URL below
-//  const TRANSLATOR_API = "TODO"
-//  const response = await fetch(TRANSLATOR_API+'/?content='+postData.content);
-//  const data = await response.json();
-//  return ['is_english','translated_content'];
-// };

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -4,9 +4,21 @@
 
 const translatorApi = module.exports;
 
+// translatorApi.translate = async function (postData) {
+//     const TRANSLATOR_API = 'http://host.docker.internal:5000';
+//     const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
+//     const data = await response.json();
+//     return [data.is_english, data.translated_content];
+// };
+
 translatorApi.translate = async function (postData) {
     const TRANSLATOR_API = 'http://host.docker.internal:5000';
-    const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
-    const data = await response.json();
-    return [data.is_english, data.translated_content];
+    try {
+        const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
+        const data = await response.json();
+        return [data.is_english, data.translated_content];
+    } catch (e) {
+        // If the API is down or any error occurs, return false and the original postData
+        return [false, postData];
+    }
 };

--- a/test/api.js
+++ b/test/api.js
@@ -688,7 +688,9 @@ describe('API', async () => {
 				return;
 			}
 
-			assert(schema[prop], `"${prop}" was found in response, but is not defined in schema (path: ${method} ${path}, context: ${context})`);
+			// assert(schema[prop], `"${prop}" was found in response, but is not 
+			// defined in schema (path: ${method} ${path}, context: ${context})`);
+			assert(schema[prop], `"${prop}" was found in response, but is not defined in schema (path: ${method} ${path}, context: ${context}), SCHEMA ${JSON.stringify(schema)}`);
 		});
 	}
 });

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -81,7 +81,15 @@
 		</div>
 
 		<div class="content text-break" component="post/content" itemprop="text">
-			{posts.content}
+			{posts.content}			
+			{{{if !posts.isEnglish }}}
+		        <div class="sensitive-content-message">
+		        <a class="btn btn-sm btn-primary view-translated-btn">Click here to view the translated message.</a>
+		        </div>
+		        <div class="translated-content" style="display:none;">
+		        {posts.translatedContent}
+		        </div>
+	        {{{end}}}
 		</div>
 
 		<div component="post/footer" class="post-footer border-bottom pb-2">


### PR DESCRIPTION
### Summary

This PR integrates the LLM Translator feature into NodeBB by adding new UI components and connecting them to the Python Flask-based microservice running on port 5000. Users can now view translated content or trigger translation directly from the post interface.

Key Changes
	1.	UI Integration
	    * Added a “Translate” button for posts written in non-English languages.
	    * Implemented dynamic display behavior to show both the original and translated text within the post container.
	    * Updated relevant template and client-side JS files (post.tpl, public/src/client/topic.js, etc.) to support real-time translation display.
	3.	API Communication
	    * Integrated NodeBB with the LLM Translator Microservice API hosted at http://localhost:5000 or in docker it would be http://host.docker.internal:5000

Testing
* Verified translation requests locally using the LLM translator microservice on port 5000.
* Tested with both English and non-English sample posts (German, Spanish, French).
* Tested for when API cannot be reached where it just returns the original language back without translating it instead of causing errors

<img width="1039" height="632" alt="IMG_0757" src="https://github.com/user-attachments/assets/0415d56a-ab75-4d0c-b3ba-d03822e6d721" />

Next Steps
* Deploying microservice to VM
